### PR TITLE
return nil value of type T if no value if found

### DIFF
--- a/tools/find.go
+++ b/tools/find.go
@@ -10,6 +10,6 @@ func Find[T any](slice []T, callback func(T) bool) T {
 	}
 
 	// Initialise nil value of type T
-	var nilvalue T
-	return nilvalue
+	var null T
+	return null
 }

--- a/tools/find.go
+++ b/tools/find.go
@@ -9,6 +9,7 @@ func Find[T any](slice []T, callback func(T) bool) T {
 		}
 	}
 
-	// TODO: fix: should return nil
-	return slice[0]
+	// Initialise nil value of type T
+	var nilvalue T
+	return nilvalue
 }


### PR DESCRIPTION
Fixes: #1 

By initialising a variable without giving it a value it defaults to the nil value. Though I think the go way to do it is, I think, by returning an non-nil error.