### PR TITLE
fix: go-version in github pipeline job to use stable version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           stable: false
-          go-version: 1.18.0
+          go-version: 1.19
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           stable: false
-          go-version: 1.18.0-beta1
+          go-version: 1.18.0
 
       - name: Build
         run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/ShauryaAg/go-functools
 
-go 1.18
+go 1.19
+
+require golang.org/x/exp v0.0.0-20221026153819-32f3d567a233

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/exp v0.0.0-20221026153819-32f3d567a233 h1:9bNbSKT4RPLEzne0Xh1v3NaNecsa1DKjkOuTbY6V9rI=
+golang.org/x/exp v0.0.0-20221026153819-32f3d567a233/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=

--- a/tools/sort.go
+++ b/tools/sort.go
@@ -1,7 +1,7 @@
 package tools
 
 import (
-	"constraints"
+	"golang.org/x/exp/constraints"
 
 	utils "github.com/ShauryaAg/go-functools/utils"
 )
@@ -26,7 +26,7 @@ func DefaultCompare[T constraints.Ordered](a, b T) bool {
 
 // Default compare function for Sort[T] with Comparable type constraint.
 //
-// Comparable type constraint is a custom constraint that checks the type 
+// Comparable type constraint is a custom constraint that checks the type
 // to contain a Compare() method.
 func DefaultCompareC[T utils.Comparable[T]](a, b T) bool {
 	return a.Compare(b) < 0

--- a/utils/math.go
+++ b/utils/math.go
@@ -1,6 +1,6 @@
 package utils
 
-import "constraints"
+import "golang.org/x/exp/constraints"
 
 // Min returns the minimum value of the two values.
 //


### PR DESCRIPTION
- [x] use `go 1.19` stable version